### PR TITLE
Added name attribute and __str__ formatter method to the desmod Queue.

### DIFF
--- a/desmod/queue.py
+++ b/desmod/queue.py
@@ -62,14 +62,16 @@ class Queue(object):
     :param hard_cap:
         If specified, the queue overflows when the `capacity` is reached.
     :param items: Optional sequence of items to pre-populate the queue.
+    :param name: Optional name to associate with the queue.
 
     """
-    def __init__(self, env, capacity=float('inf'), hard_cap=False, items=()):
+    def __init__(self, env, capacity=float('inf'), hard_cap=False, items=(), name=None):
         self.env = env
         #: Capacity of the queue (maximum number of items).
         self.capacity = capacity
         self._hard_cap = hard_cap
         self.items = list(items)
+        self.name = name
         self._putters = []
         self._getters = []
         self._any_waiters = []
@@ -142,6 +144,12 @@ class Queue(object):
             for when_full_ev in self._full_waiters:
                 when_full_ev.succeed()
             del self._full_waiters[:]
+
+    def __str__(self):
+        return ('Queue: name={0.name}'
+                ' size={1}'
+                ' capacity={0.capacity}'
+                ')'.format(self, len(self.items)))
 
 
 class PriorityItem(namedtuple('PriorityItem', 'priority item')):

--- a/desmod/queue.py
+++ b/desmod/queue.py
@@ -65,7 +65,8 @@ class Queue(object):
     :param name: Optional name to associate with the queue.
 
     """
-    def __init__(self, env, capacity=float('inf'), hard_cap=False, items=(), name=None):
+    def __init__(self, env, capacity=float('inf'), hard_cap=False, items=(),
+                 name=None):
         self.env = env
         #: Capacity of the queue (maximum number of items).
         self.capacity = capacity

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 pytest >= 2.9.0
 pytest-cov >= 2.2.1
 pytest-flake8 >= 0.2
+flake8 < 3.0.0
 tox >= 2.3.1
 setuptools-scm >= 1.11.1
 Sphinx


### PR DESCRIPTION
Added a "name" attribute to the desmod Queue. This is useful when queue objects are passed around the model and we need an easy way to identify them. For example, a queue "foo" that resides in component "x.y.z" could be given the name "x.y.z.foo" by instantiating the Queue with:
`foo = Queue(name=self.scope + ."foo")`
