### PR TITLE
Repair pytest-flake8 and flake8 dependency issue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 pytest >= 2.9.0
 pytest-cov >= 2.2.1
 pytest-flake8 >= 0.2
+flake8 < 3.0.0
 tox >= 2.3.1
 setuptools-scm >= 1.11.1
 Sphinx


### PR DESCRIPTION
pytest-flake8 is not yet compatible with the new flake-3.x. We update
requirements-dev.txt to force a compatible version of pyflakes.
