### PR TITLE
Add Queue.size and Queue.remaining properties

### DIFF
--- a/desmod/queue.py
+++ b/desmod/queue.py
@@ -106,6 +106,16 @@ class Queue(object):
         BoundClass.bind_early(self)
 
     @property
+    def size(self):
+        """Number of items in queue."""
+        return len(self.items)
+
+    @property
+    def remaining(self):
+        """Remaining queue capacity."""
+        return self.capacity - len(self.items)
+
+    @property
     def is_empty(self):
         """Indicates whether the queue is empty."""
         return not self.items


### PR DESCRIPTION
These new properties provide convenient access to the queue's size and
remaining capacity without requiring the user to inspect the queue's
[internal] items list.
