### PR TITLE
Breaking changes for desmod 0.2.0

### DIFF
--- a/desmod/component.py
+++ b/desmod/component.py
@@ -80,21 +80,17 @@ class Component(object):
     :param int index:
         Optional index of Component. This is used when multiple sibling
         components of the same type are instantiated as an array/list.
-    :param TraceManager tracemgr:
-        The :func:`desmod.simulation.simulate()` function is responsible for
-        this TraceManager parameter.
 
     """
 
     #: Short/friendly name used in the scope (class attribute).
     base_name = ''
 
-    def __init__(self, parent, env=None, name=None, index=None, tracemgr=None):
-        assert parent or (env and tracemgr)
+    def __init__(self, parent, env=None, name=None, index=None):
+        assert parent or env
 
         #: The simulation environment; a :class:`SimEnvironment` instance.
         self.env = parent.env if env is None else env
-        self.tracemgr = parent.tracemgr if tracemgr is None else tracemgr
 
         #: The component name (str).
         self.name = ((self.base_name if name is None else name) +
@@ -120,16 +116,16 @@ class Component(object):
         self._not_connected = set()
 
         #: Log an error message.
-        self.error = self.tracemgr.get_trace_function(
+        self.error = self.env.tracemgr.get_trace_function(
             self.scope, log={'level': 'ERROR'})
         #: Log a warning message.
-        self.warn = self.tracemgr.get_trace_function(
+        self.warn = self.env.tracemgr.get_trace_function(
             self.scope, log={'level': 'WARNING'})
         #: Log an informative message.
-        self.info = self.tracemgr.get_trace_function(
+        self.info = self.env.tracemgr.get_trace_function(
             self.scope, log={'level': 'INFO'})
         #: Log a debug message.
-        self.debug = self.tracemgr.get_trace_function(
+        self.debug = self.env.tracemgr.get_trace_function(
             self.scope, log={'level': 'DEBUG'})
 
     def add_process(self, process_func, *args, **kwargs):
@@ -235,11 +231,11 @@ class Component(object):
         if target is None:
             target = getattr(self, name)
         target_scope = '.'.join([self.scope, name])
-        self.tracemgr.auto_probe(target_scope, target, **hints)
+        self.env.tracemgr.auto_probe(target_scope, target, **hints)
 
     def get_trace_function(self, name, **hints):
         target_scope = '.'.join([self.scope, name])
-        return self.tracemgr.get_trace_function(target_scope, **hints)
+        return self.env.tracemgr.get_trace_function(target_scope, **hints)
 
     @classmethod
     def pre_init(cls, env):

--- a/desmod/config.py
+++ b/desmod/config.py
@@ -134,7 +134,7 @@ def parse_user_factors(config, user_factors, eval_locals=None):
         expressions.
     :returns:
         List of keys, values pairs. The returned list of factors is suitable
-        for assigning to `config['sim.factors']`.
+        for passing to :func:`simulate_factors`.
     :raises `desmod.config.ConfigError`: For invalid user keys or expressions.
 
     """

--- a/desmod/simulation.py
+++ b/desmod/simulation.py
@@ -152,11 +152,14 @@ def simulate_factors(base_config, top_type,
     """
     factors = base_config['sim.factors']
     configs = list(factorial_config(base_config, factors, 'sim.special'))
-    base_workspace = base_config['sim.workspace']
+    base_workspace = base_config.setdefault('sim.workspace', os.curdir)
+    overwrite = base_config.setdefault('sim.workspace.overwrite', False)
     for seq, config in enumerate(configs):
         config['sim.factors'] = []
         config['sim.workspace'] = os.path.join(base_workspace, str(seq))
-    if os.path.isdir(base_workspace):
+    if (overwrite and
+            os.path.relpath(base_workspace) != os.curdir and
+            os.path.isdir(base_workspace)):
         shutil.rmtree(base_workspace)
     return simulate_many(configs, top_type, env_type, jobs)
 

--- a/desmod/simulation.py
+++ b/desmod/simulation.py
@@ -147,33 +147,29 @@ def simulate(config, top_type, env_type=SimEnvironment, reraise=True):
     return result
 
 
-def simulate_factors(base_config, top_type,
+def simulate_factors(base_config, factors, top_type,
                      env_type=SimEnvironment, jobs=None):
     """Run multi-factor simulations in separate processes.
 
-    The `'sim.factors'` found in `base_config` are used to compose specialized
-    config dictionaries for the simulations.
+    The `factors` are used to compose specialized config dictionaries for the
+    simulations.
 
     The :mod:`python:multiprocessing` module is used run each simulation with a
     separate Python process. This allows multi-factor simulations to run in
     parallel on all available CPU cores.
 
-    :param dict base_config:
-        Base configuration dictionary to be specialized. Must contain the
-        `'sim.factors'` key/value which specifies one or more configuration
-        factors.
+    :param dict base_config: Base configuration dictionary to be specialized.
+    :param list factors: List of factors.
     :param top_type: The model's top-level Component subclass.
     :param env_type: :class:`SimEnvironment` subclass.
     :param int jobs: User specified number of concurent processes.
     :returns: Sequence of result dictionaries for each simulation.
 
     """
-    factors = base_config['sim.factors']
     configs = list(factorial_config(base_config, factors, 'sim.special'))
     base_workspace = base_config.setdefault('sim.workspace', os.curdir)
     overwrite = base_config.setdefault('sim.workspace.overwrite', False)
     for seq, config in enumerate(configs):
-        config['sim.factors'] = []
         config['sim.workspace'] = os.path.join(base_workspace, str(seq))
     if (overwrite and
             os.path.relpath(base_workspace) != os.curdir and

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+progressbar2 >= 3.10.1
 pytest >= 3.0.3
 pytest-cov >= 2.4.0
 pytest-flake8 >= 0.6

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -139,8 +139,8 @@ def test_no_result_file(config):
 
 
 def test_simulate_factors(config):
-    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, factors, TopTest)
     assert len(results) == 3
     for result in results:
         assert result['sim.exception'] is None
@@ -151,8 +151,8 @@ def test_simulate_factors(config):
 
 def test_simulate_factors_no_overwrite(config):
     config['sim.workspace.overwrite'] = False
-    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, factors, TopTest)
     assert os.path.isdir(config['sim.workspace'])
     assert len(results) == 3
     for result in results:
@@ -164,8 +164,8 @@ def test_simulate_factors_no_overwrite(config):
     with open(os.path.join(config['sim.workspace'], 'cookie.txt'), 'w') as f:
         f.write('hi')
 
-    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3], [4]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2], [3], [4]])]
+    results = simulate_factors(config, factors, TopTest)
     assert len(results) == 4
     assert os.path.isdir(config['sim.workspace'])
     for result in results:
@@ -180,8 +180,8 @@ def test_simulate_factors_no_overwrite(config):
 
 def test_simulate_factors_overwrite(config):
     config['sim.workspace.overwrite'] = True
-    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, factors, TopTest)
     assert os.path.isdir(config['sim.workspace'])
     assert len(results) == 3
     for result in results:
@@ -193,8 +193,8 @@ def test_simulate_factors_overwrite(config):
     with open(os.path.join(config['sim.workspace'], 'cookie.txt'), 'w') as f:
         f.write('hi')
 
-    config['sim.factors'] = [(['sim.seed'], [[1], [2]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2]])]
+    results = simulate_factors(config, factors, TopTest)
     assert len(results) == 2
     assert os.path.isdir(config['sim.workspace'])
     for result in results:
@@ -221,8 +221,8 @@ def test_progress_enabled(config):
 
 def test_many_progress_enabled(config):
     config['sim.progress.enable'] = True
-    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
-    results = simulate_factors(config, TopTest)
+    factors = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, factors, TopTest)
     for result in results:
         assert result['sim.exception'] is None
         assert result['sim.now'] == 1

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2,13 +2,26 @@ import os
 import pytest
 
 from desmod.component import Component
-from desmod.simulation import simulate, SimEnvironment
+from desmod.simulation import simulate, simulate_factors, SimEnvironment
+
+
+pytestmark = pytest.mark.usefixtures('cleandir')
+
+
+@pytest.fixture
+def cleandir(tmpdir):
+    origin = os.getcwd()
+    tmpdir.chdir()
+    yield None
+    os.chdir(origin)
 
 
 @pytest.fixture
 def config():
     return {
+        'sim.result.file': 'result.yaml',
         'sim.workspace': 'workspace',
+        'sim.workspace.overwrite': False,
         'sim.timescale': '1 us',
         'sim.seed': 1234,
         'sim.duration': '1 us',
@@ -38,9 +51,10 @@ class TopTest(Component):
         self.add_process(self.test_proc)
 
     def test_proc(self):
+        yield self.env.timeout(0.5)
         if self.env.config.get('test.fail_simulate'):
-            raise Exception('fail_simulate')
-        yield self.env.timeout(1)
+            assert False, 'fail_simulate'
+        yield self.env.timeout(0.5)
 
     def post_sim_hook(self):
         if self.env.config.get('test.fail_post_simulate'):
@@ -51,23 +65,227 @@ class TopTest(Component):
             raise Exception('fail_get_result')
 
 
-def test_workspace_env_init(tmpdir, config):
+def test_pre_init_failure(config):
+    config['test.fail_pre_init'] = True
+    result = simulate(config, TopTest, reraise=False)
+    assert result['sim.exception'] == repr(Exception('fail_pre_init'))
+    assert result['sim.now'] == 0
+    assert result['sim.time'] == 0
+    assert result['sim.runtime'] > 0
+    assert result['config']['test.fail_pre_init']
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_init_failure(config):
+    config['test.fail_init'] = True
+    result = simulate(config, TopTest, reraise=False)
+    assert result['sim.exception'] == repr(Exception('fail_init'))
+    assert result['sim.now'] == 0
+    assert result['sim.time'] == 0
+    assert result['sim.runtime'] > 0
+    assert result['config']['test.fail_init']
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_simulate_fail(config):
+    config['test.fail_simulate'] = True
+    result = simulate(config, TopTest, reraise=False)
+    assert result['sim.exception'].startswith('AssertionError')
+    assert result['sim.now'] == 0.5
+    assert result['sim.time'] == 0.5e-6
+    assert result['sim.runtime'] > 0
+    assert result['config']['test.fail_simulate']
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_post_simulate_fail(config):
+    config['test.fail_post_simulate'] = True
+    result = simulate(config, TopTest, reraise=False)
+    assert result['sim.exception'] == repr(Exception('fail_post_simulate'))
+    assert result['sim.now'] == 1
+    assert result['sim.time'] == 1e-6
+    assert result['sim.runtime'] > 0
+    assert result['config']['test.fail_post_simulate']
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_get_result_fail(config):
+    config['test.fail_get_result'] = True
+    result = simulate(config, TopTest, reraise=False)
+    assert result['sim.exception'] == repr(Exception('fail_get_result'))
+    assert result['sim.now'] == 1
+    assert result['sim.time'] == 1e-6
+    assert result['sim.runtime'] > 0
+    assert result['config']['test.fail_get_result']
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_simulate_reraise(config):
+    config['test.fail_simulate'] = True
+    with pytest.raises(AssertionError):
+        simulate(config, TopTest, reraise=True)
+
+
+def test_no_result_file(config):
+    config.pop('sim.result.file')
+    result = simulate(config, TopTest)
+    assert result['sim.exception'] is None
+    assert not os.listdir(config['sim.workspace'])
+
+
+def test_simulate_factors(config):
+    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, TopTest)
+    assert len(results) == 3
+    for result in results:
+        assert result['sim.exception'] is None
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+
+def test_simulate_factors_no_overwrite(config):
+    config['sim.workspace.overwrite'] = False
+    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, TopTest)
+    assert os.path.isdir(config['sim.workspace'])
+    assert len(results) == 3
+    for result in results:
+        assert result['sim.exception'] is None
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+    with open(os.path.join(config['sim.workspace'], 'cookie.txt'), 'w') as f:
+        f.write('hi')
+
+    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3], [4]])]
+    results = simulate_factors(config, TopTest)
+    assert len(results) == 4
+    assert os.path.isdir(config['sim.workspace'])
+    for result in results:
+        assert result['sim.exception'] is None
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+    with open(os.path.join(config['sim.workspace'], 'cookie.txt')) as f:
+        assert f.read() == 'hi'
+
+
+def test_simulate_factors_overwrite(config):
+    config['sim.workspace.overwrite'] = True
+    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, TopTest)
+    assert os.path.isdir(config['sim.workspace'])
+    assert len(results) == 3
+    for result in results:
+        assert result['sim.exception'] is None
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+    with open(os.path.join(config['sim.workspace'], 'cookie.txt'), 'w') as f:
+        f.write('hi')
+
+    config['sim.factors'] = [(['sim.seed'], [[1], [2]])]
+    results = simulate_factors(config, TopTest)
+    assert len(results) == 2
+    assert os.path.isdir(config['sim.workspace'])
+    for result in results:
+        assert result['sim.exception'] is None
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+    assert not os.path.exists(os.path.join(config['sim.workspace'],
+                                           'cookie.txt'))
+    assert set(os.listdir(config['sim.workspace'])) == set(['0', '1'])
+
+
+def test_progress_enabled(config):
+    config['sim.progress.enable'] = True
+    result = simulate(config, TopTest)
+    assert result['sim.exception'] is None
+    assert result['sim.now'] == 1
+    assert result['sim.time'] == 1e-6
+    assert result['sim.runtime'] > 0
+    assert os.path.exists(os.path.join(config['sim.workspace'],
+                                       config['sim.result.file']))
+
+
+def test_many_progress_enabled(config):
+    config['sim.progress.enable'] = True
+    config['sim.factors'] = [(['sim.seed'], [[1], [2], [3]])]
+    results = simulate_factors(config, TopTest)
+    for result in results:
+        assert result['sim.exception'] is None
+        assert result['sim.now'] == 1
+        assert result['sim.time'] == 1e-6
+        assert result['sim.runtime'] > 0
+        assert os.path.exists(
+            os.path.join(result['config']['sim.workspace'],
+                         result['config']['sim.result.file']))
+
+
+def test_workspace_env_init(config):
     class TestEnvironment(SimEnvironment):
         def __init__(self, config):
             super(TestEnvironment, self).__init__(config)
             assert os.path.split(os.getcwd())[-1] == config['sim.workspace']
 
-    with tmpdir.as_cwd():
-        workspace = config['sim.workspace']
-        assert not os.path.exists(workspace)
-        simulate(config, TopTest, TestEnvironment)
-        assert os.path.exists(workspace)
+    workspace = config['sim.workspace']
+    assert not os.path.exists(workspace)
+    simulate(config, TopTest, TestEnvironment)
+    assert os.path.exists(workspace)
 
 
-def test_sim_time(tmpdir, config):
+def test_workspace_no_overwrite(config):
+    workspace = config['sim.workspace']
+
+    config['sim.workspace.overwrite'] = True
+    config['sim.result.file'] = 'first-result.yaml'
+    assert not os.path.exists(workspace)
+    simulate(config, TopTest)
+    assert os.path.exists(os.path.join(workspace, 'first-result.yaml'))
+
+    config['sim.workspace.overwrite'] = False
+    config['sim.result.file'] = 'second-result.yaml'
+    simulate(config, TopTest)
+    assert os.path.exists(os.path.join(workspace, 'first-result.yaml'))
+    assert os.path.exists(os.path.join(workspace, 'second-result.yaml'))
+
+    config['sim.workspace.overwrite'] = True
+    config['sim.result.file'] = 'third-result.yaml'
+    simulate(config, TopTest)
+    assert not os.path.exists(os.path.join(workspace, 'first-result.yaml'))
+    assert not os.path.exists(os.path.join(workspace, 'second-result.yaml'))
+    assert os.path.exists(os.path.join(workspace, 'third-result.yaml'))
+
+
+def test_workspace_is_curdir(config):
+    config['sim.workspace'] = '.'
+    config['sim.workspace.overwrite'] = True
+    config['sim.result.file'] = 'first-result.yaml'
+    simulate(config, TopTest)
+    assert os.path.exists('first-result.yaml')
+
+    config['sim.workspace.overwrite'] = True
+    config['sim.result.file'] = 'second-result.yaml'
+    simulate(config, TopTest)
+    # '.' is not supposed to be overwritten
+    assert os.path.exists('first-result.yaml')
+    assert os.path.exists('second-result.yaml')
+
+
+def test_sim_time(config):
     config['sim.timescale'] = '10 ms'
     config['sim.duration'] = '995 ms'
-    with tmpdir.as_cwd():
-        result = simulate(config, TopTest)
-        assert result['sim.time'] == 0.995
-        assert result['sim.now'] == 99.5
+    result = simulate(config, TopTest)
+    assert result['sim.time'] == 0.995
+    assert result['sim.now'] == 99.5


### PR DESCRIPTION
These commits make some breaking changes to desmod's `simulate_factors()` and `simulate_many()` interfaces.

Namely, `simulate_factors()` now requires a `factors` argument instead of inspecting `config['sim.factors']`.

Also, `simulate_factors()` and `simulate_many()` now squash exceptions from subordinate simulation processes. This puts a new onus on the callers of those functions to inspect the 'sim.exception' item in the returned results dicts.

Another potentially breaking change is that the config dictionary is updated (via `dict.setdefault()`) with missing config items that desmod provides defaults for. This means that more/extra config items may appear in the result dict and result YAML file.

This set of commits also introduces a relatively complete unit test suite for the desmod.simulation module.
