### PR TITLE
Use pyenv for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 language: python
 
-python:
-  - 2.7
-  - pypy
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy3
-
 matrix:
-  allow_failures:
-    python: pypy3
+  include:
+    - python: '2.7'
+    - python: 'pypy'
+      env: PYENV_VERSION=pypy-portable-5.7.0 PYENV_VERSION_STRING='PyPy 5.7.0'
+    - python: '3.3'
+    - python: '3.4'
+    - python: '3.5'
+    - python: '3.6'
+    - python: 'pypy3'
+      env: PYENV_VERSION=pypy3-portable-5.7.0 PYENV_VERSION_STRING='PyPy 5.7.0'
+
+before_install:
+  - |
+      if [[ -n "$PYENV_VERSION" ]]; then
+        wget https://github.com/praekeltfoundation/travis-pyenv/releases/download/0.3.0/setup-pyenv.sh
+        source setup-pyenv.sh
+      fi
 
 install:
   - pip install -r requirements-dev.txt
@@ -22,3 +28,8 @@ script: py.test --flake8 --cov
 
 after_success:
   coveralls
+
+cache:
+  - pip
+  - directories:
+    - "${PYENV_CACHE_PATH:-$HOME/.pyenv_cache}"


### PR DESCRIPTION
The pyenv tool is capable of retrieving and using up-to-date versions of
PyPy2 and PyPy3. We make this change in the hope of making the TravisCI
PyPy tests more reliable.